### PR TITLE
docs: Fix small typo in readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ import { Parser } from 'n3';
 
 const parser = new Parser({ format: 'text/n3' });
 export const queryQuads = parser.parse(queryString);
-export const resultQuads = parser.parse(dataString);
+export const dataQuads = parser.parse(dataString);
 
 // The result of the query (as an array of quads)
 const resultQuads = await n3reasoner(dataQuads, queryQuads);


### PR DESCRIPTION
I spotted a small typo in the example