### PR TITLE
chore/reduce memory test time

### DIFF
--- a/__tests_memory__/browserLeakTest.js
+++ b/__tests_memory__/browserLeakTest.js
@@ -8,12 +8,12 @@ async function main() {
   const leaks = await run({scenario: {
     url: () => 'http://localhost:3000/',
     action: async page => {
-      for (let i = 0; i < 200; i += 1) {
+      for (let i = 0; i < 3; i += 1) {
         await page.click('button[id=execute]')
       }
     },
     back: page => page.click('button[id=clear]'),
-    repeat: () => 5,
+    repeat: () => 3,
   }});
 
   server.close();

--- a/__tests_memory__/leakTest.js
+++ b/__tests_memory__/leakTest.js
@@ -50,7 +50,7 @@ async function main() {
 
   let maxCont = 0;
 
-  for (let i = 0; i <= 1000; i++) {
+  for (let i = 0; i <= 500; i++) {
     // Allow for GC
     await new Promise(res => setTimeout(res, 0));
 

--- a/__tests_memory__/leakTestOnError.js
+++ b/__tests_memory__/leakTestOnError.js
@@ -34,7 +34,7 @@ async function main() {
 
   let maxCont = 0;
 
-  for (let i = 0; i <= 1000; i++) {
+  for (let i = 0; i <= 500; i++) {
     // Allow for GC
     await new Promise(res => setTimeout(res, 0));
 


### PR DESCRIPTION
Should solve the timeout issues of https://github.com/eyereasoner/eye-js/actions/runs/4844917901/attempts/1 but doesn't solve the underlying performance degradation that we are observing.