### PR TITLE
chore: don't comment on dependabot PRs

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -86,7 +86,7 @@ jobs:
         gh-pages-branch: pages
         auto-push: ${{ github.ref == 'refs/heads/main' }}
         save-data-file: ${{ github.ref == 'refs/heads/main' }}
-        comment-always: true
+        comment-always: ${{ ! contains(github.ref, 'dependabot/npm_and_yarn/') }}
 
   eslint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Otherwise we get errors like https://github.com/eyereasoner/eye-js/actions/runs/4910662407/jobs/8768023966?pr=305 because tokens are not available in that environment