### PR TITLE
test log:semantics

### DIFF
--- a/__test_utils__/util.ts
+++ b/__test_utils__/util.ts
@@ -3,6 +3,7 @@ import type { Quad } from '@rdfjs/types';
 import 'jest-rdf';
 import { DataFactory, Parser, Store } from 'n3';
 import { data, dataStar, query, queryAll, result } from '../data/socrates';
+import { querySemantics, dataSemantics, resultSemantics } from '../data/semantics';
 import { n3reasoner } from '../dist';
 import { data as blogicData, result as blogicResult } from '../data/blogic';
 
@@ -17,6 +18,9 @@ export const dataQuads = parser.parse(data);
 export const dataStarQuads = parser.parse(dataStar);
 export const resultQuads = parser.parse(result);
 export const resultBlogicQuads = parser.parse(blogicResult);
+export const querySemanticsQuads = parser.parse(querySemantics);
+export const dataSemanticsQuads = parser.parse(dataSemantics);
+export const resultSemanticsQuads = parser.parse(resultSemantics);
 
 export function mockFetch(...args: Parameters<typeof fetch>): ReturnType<typeof fetch> {
   switch (args[0]) {
@@ -83,6 +87,10 @@ export function universalTests() {
     it('should execute the n3reasoner [quad input quad output] [output: undefined]', () => expect<Promise<Quad[]>>(
       n3reasoner(dataQuads, queryQuads, { output: undefined }),
     ).resolves.toBeRdfIsomorphic(resultQuads));
+
+    it('should execute the n3reasoner with log:semantics [quad input quad output] [output: undefined]', () => expect<Promise<Quad[]>>(
+      n3reasoner(dataSemanticsQuads, querySemanticsQuads, { output: undefined }),
+    ).resolves.toBeRdfIsomorphic(resultSemanticsQuads));
 
     it('should execute the n3reasoner [quad input quad output] [output: deductive_closure]', () => expect<Promise<string>>(
       n3reasoner(dataQuads, '{?S a ?O} => {?S a ?O}.', { output: 'deductive_closure', outputType: 'string' }),

--- a/data/semantics.ts
+++ b/data/semantics.ts
@@ -1,0 +1,32 @@
+export const querySemantics = `
+@prefix : <http://ex.org/> .
+@prefix log: <http://www.w3.org/2000/10/swap/log#> .
+
+{ :test :people ?people } => { :test :people ?people } .
+`;
+
+export const dataSemantics = `
+@prefix : <http://ex.org/> .
+@prefix log: <http://www.w3.org/2000/10/swap/log#> .
+
+{
+    <https://raw.githubusercontent.com/w3c/N3/master/tests/N3Tests/people.n3> log:semantics ?people .
+}
+=>
+{
+    :test :people ?people
+}
+.
+`;
+
+export const resultSemantics = `
+@prefix : <http://ex.org/>.
+@prefix log: <http://www.w3.org/2000/10/swap/log#>.
+@prefix ns1: <http://example.com/>.
+
+:test :people {
+    ns1:william a ns1:Person.
+    ns1:doerthe a ns1:Person.
+    ns1:gregg a ns1:Person.
+}.
+`;


### PR DESCRIPTION
Can be merged only after [log:semantics support](https://github.com/eyereasoner/eye-js/issues/306) is added.

I could think of a single test case. The resource used is the same as in the [spec example](https://w3c.github.io/N3/spec/#access-online-knowledge).
