### PR TITLE
Allow query and data to be in other directories. Fixes #1585

### DIFF
--- a/lib/bin/main.ts
+++ b/lib/bin/main.ts
@@ -20,9 +20,6 @@ export async function mainFunc(proc: NodeJS.Process) {
       // Create any subdirectories needed for this file path
       const dirname = path.dirname(arg);
       // @ts-ignore: mkdirTree exists in Emscripten FS but is not typed.
-      // Note that the implementation of mkdirTree looks for `/` path separators
-      // so we need to convert it to a posix path first for use
-      // in the emscripten FS module.
       Module.FS.mkdirTree(dirname);
 
       // Now write the file to the correct path

--- a/lib/bin/main.ts
+++ b/lib/bin/main.ts
@@ -4,7 +4,6 @@ import readline from 'readline';
 import { SwiplEye } from '..';
 import { qaQuery } from '../query';
 
-
 export async function mainFunc(proc: NodeJS.Process) {
   const rl = readline.promises.createInterface({
     input: proc.stdin,

--- a/lib/bin/main.ts
+++ b/lib/bin/main.ts
@@ -1,19 +1,19 @@
-import path from 'path';
+import path, { PlatformPath } from 'path';
 import fs from 'fs';
 import readline from 'readline';
 import { SwiplEye } from '..';
 import { qaQuery } from '../query';
 
-export function convertToPosixPath(filePath: string): string {
+export function convertToPosixPath(filePath: string, pathLib: PlatformPath = path): string {
   // For the Emscripten FS, we need to ensure posix separators
   // for any relative sub-path that may have been typed in
   // on w32 as subdir\socrates.n3
 
   // First normalize the path to handle any path oddities
-  const normalizedPath = path.normalize(filePath);
+  const normalizedPath = pathLib.normalize(filePath);
 
   // Then split by platform-specific separator and join with POSIX separator
-  return normalizedPath.split(path.sep).join(path.posix.sep);
+  return normalizedPath.split(pathLib.sep).join(pathLib.posix.sep);
 }
 
 export async function mainFunc(proc: NodeJS.Process) {

--- a/lib/bin/main.ts
+++ b/lib/bin/main.ts
@@ -24,7 +24,12 @@ function createAnySubdirs(Module: any, filePath: string): void {
   for (const dir of dirs) {
     if (dir !== '') {
       currentPath += (currentPath ? '/' : '') + dir;
-      Module.FS.mkdir(currentPath);
+      try {
+        Module.FS.stat(currentPath);
+      } catch {
+        // Directory doesn't exist, create it
+        Module.FS.mkdir(currentPath);
+      }
     }
   }
 }

--- a/lib/bin/main.ts
+++ b/lib/bin/main.ts
@@ -17,13 +17,18 @@ export async function mainFunc(proc: NodeJS.Process) {
   for (const arg of proc.argv.slice(2)) {
     const p = path.join(proc.cwd(), arg);
     if (fs.existsSync(p)) {
+      // For the Emscripten FS, we need to ensure posix separators
+      // for any relative sub-path that may have been typed in
+      // on w32 as subdir\socrates.n3
+      const posixPath = arg.replace(path.sep, path.posix.sep);
+
       // Create any subdirectories needed for this file path
-      const dirname = path.dirname(arg);
+      const dirname = path.dirname(posixPath);
       // @ts-ignore: mkdirTree exists in Emscripten FS but is not typed.
       Module.FS.mkdirTree(dirname);
 
       // Now write the file to the correct path
-      Module.FS.writeFile(arg, fs.readFileSync(p));
+      Module.FS.writeFile(posixPath, fs.readFileSync(p));
     }
   }
 

--- a/lib/bin/main.ts
+++ b/lib/bin/main.ts
@@ -4,6 +4,18 @@ import readline from 'readline';
 import { SwiplEye } from '..';
 import { qaQuery } from '../query';
 
+export function convertToPosixPath(filePath: string): string {
+  // For the Emscripten FS, we need to ensure posix separators
+  // for any relative sub-path that may have been typed in
+  // on w32 as subdir\socrates.n3
+
+  // First normalize the path to handle any path oddities
+  const normalizedPath = path.normalize(filePath);
+
+  // Then split by platform-specific separator and join with POSIX separator
+  return normalizedPath.split(path.sep).join(path.posix.sep);
+}
+
 export async function mainFunc(proc: NodeJS.Process) {
   const rl = readline.promises.createInterface({
     input: proc.stdin,
@@ -12,25 +24,28 @@ export async function mainFunc(proc: NodeJS.Process) {
 
   const Module = await SwiplEye();
 
+  const posixArgv: string[] = [];
   // Make any local files available to the reasoner
   for (const arg of proc.argv.slice(2)) {
     const p = path.join(proc.cwd(), arg);
     if (fs.existsSync(p)) {
-      // For the Emscripten FS, we need to ensure posix separators
-      // for any relative sub-path that may have been typed in
-      // on w32 as subdir\socrates.n3
-      const posixPath = arg.replace(path.sep, path.posix.sep);
+      const posixPath = convertToPosixPath(arg);
+      posixArgv.push(posixPath);
 
       // Create any subdirectories needed for this file path
       const dirname = path.dirname(posixPath);
       // @ts-ignore: mkdirTree exists in Emscripten FS but is not typed.
+      // https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/72434
       Module.FS.mkdirTree(dirname);
 
       // Now write the file to the correct path
       Module.FS.writeFile(posixPath, fs.readFileSync(p));
+    } else {
+      // For non-filepath arguments, keep them as-is
+      posixArgv.push(arg);
     }
   }
 
-  await qaQuery(Module, 'main', proc.argv.slice(2), (q) => rl.question(`${q}\n|: `));
+  await qaQuery(Module, 'main', posixArgv, (q) => rl.question(`${q}\n|: `));
   rl.close();
 }

--- a/lib/bin/main.ts
+++ b/lib/bin/main.ts
@@ -4,6 +4,31 @@ import readline from 'readline';
 import { SwiplEye } from '..';
 import { qaQuery } from '../query';
 
+/**
+ * Creates any subdirectories needed for a file path in the virtual filesystem
+ * @param Module The SWIPL module with FS access
+ * @param filePath The file path that may contain subdirectories
+ */
+function createAnySubdirs(Module: any, filePath: string): void {
+  const dirname = path.dirname(filePath);
+
+  // No need to create directories if the file is in the root
+  if (dirname === '.' || dirname === '/') {
+    return;
+  }
+
+  // Split the directory path and create each level
+  const dirs = dirname.split('/');
+  let currentPath = '';
+
+  for (const dir of dirs) {
+    if (dir !== '') {
+      currentPath += (currentPath ? '/' : '') + dir;
+      Module.FS.mkdir(currentPath);
+    }
+  }
+}
+
 export async function mainFunc(proc: NodeJS.Process) {
   const rl = readline.promises.createInterface({
     input: proc.stdin,
@@ -16,6 +41,10 @@ export async function mainFunc(proc: NodeJS.Process) {
   for (const arg of proc.argv.slice(2)) {
     const p = path.join(proc.cwd(), arg);
     if (fs.existsSync(p)) {
+      // Create any subdirectories needed for this file path
+      createAnySubdirs(Module, arg);
+
+      // Now write the file to the correct path
       Module.FS.writeFile(arg, fs.readFileSync(p));
     }
   }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test:coverage": "npm test -- --coverage",
     "test:badges": "npm run test:coverage  && jest-coverage-badges",
     "test:unit": "npm run bundle:webpack && jest",
+    "test:cli": "npm run bundle:webpack && jest cli-test",
     "test:memory": "npm run test:memory:node && npm run test:memory:node:error && npm run test:memory:browser",
     "test:memory:node": "node __tests_memory__/leakTest",
     "test:memory:node:error": "node __tests_memory__/leakTestOnError",


### PR DESCRIPTION
See #1585 . The issue was that the file-path `./sub-dir/socrates.r3` was being written without first creating the sub directory.

The simple solution (creating subdirectories) probably won't work if people try to use `../other-dir/socrates.r3`, but it's a step in the right direction, I think.

Fixes #1585