### PR TITLE
fix: typo in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "description": "Distributing the [EYE](https://github.com/eyereasoner/eye) reasoner for browser and node using WebAssembly.",
   "main": "dist/index.js",
-  "types": "dist/index.d.js",
+  "types": "dist/index.d.ts",
   "directories": {
     "lib": "lib"
   },


### PR DESCRIPTION
Correct package.json to load TS declaration file
- Before: `"types": "dist/index.d.js"`
- After: `"types": "dist/index.d.ts"`