### PR TITLE
fix: Parse quad results from the reasoner and drop the obsolete RDF-star workaround

### DIFF
--- a/__test_utils__/util.ts
+++ b/__test_utils__/util.ts
@@ -12,9 +12,6 @@ import { query as surfaceSocratesQuery, queryResult as surfaceSocratesResult } f
 import { mapTerms } from 'rdf-terms';
 
 const parser = new Parser({ format: 'text/n3' });
-// Workaround for https://github.com/rdfjs/N3.js/issues/324
-// @ts-expect-error
-parser._supportsRDFStar = true;
 
 export const queryQuads = parser.parse(query);
 export const queryAllQuads = parser.parse(queryAll)

--- a/__tests__/node-test.ts
+++ b/__tests__/node-test.ts
@@ -1,6 +1,38 @@
 /**
  * @jest-environment node
  */
+import type { Quad } from '@rdfjs/types';
+import 'jest-rdf';
+import { DataFactory, Parser } from 'n3';
 import { universalTests } from '../__test_utils__/util';
+import { n3reasoner } from '../dist';
 
 universalTests();
+
+// Regression tests for https://github.com/eyereasoner/eye-js/issues/1642
+// (parse error when the query result contains quads / named graphs)
+describe('testing n3reasoner with quad (named graph) results', () => {
+  const quadData = '<http://dbpedia.org/resource/Belgium> <http://dbpedia.org/ontology/PopulatedPlace/areaTotal> "30528.189856530433"^^<http://dbpedia.org/datatype/squareKilometre> <http://example.com/graph>.';
+  const quadRule = '{ ?s ?p ?o ?g } => { ?s ?p ?o ?g }.';
+  const expectedQuads = [
+    DataFactory.quad(
+      DataFactory.namedNode('http://dbpedia.org/resource/Belgium'),
+      DataFactory.namedNode('http://dbpedia.org/ontology/PopulatedPlace/areaTotal'),
+      DataFactory.literal('30528.189856530433', DataFactory.namedNode('http://dbpedia.org/datatype/squareKilometre')),
+      DataFactory.namedNode('http://example.com/graph'),
+    ),
+  ];
+
+  it('should preserve the graph term [outputType: quads]', async () => {
+    const quads: Quad[] = await n3reasoner(quadData, quadRule, { outputType: 'quads' });
+    expect(quads).toHaveLength(1);
+    expect(quads[0].graph.termType).toEqual('NamedNode');
+    expect(quads[0].graph.value).toEqual('http://example.com/graph');
+    expect(quads).toBeRdfIsomorphic(expectedQuads);
+  });
+
+  it('should preserve the graph term [outputType: string]', async () => {
+    const resultStr: string = await n3reasoner(quadData, quadRule, { outputType: 'string' });
+    expect<Quad[]>(new Parser().parse(resultStr)).toBeRdfIsomorphic(expectedQuads);
+  });
+});

--- a/lib/transformers.ts
+++ b/lib/transformers.ts
@@ -117,15 +117,18 @@ export function runQuery(
 }
 
 function parse(res: string) {
-  const parser = new Parser({ format: 'text/n3' });
-  // Workaround for https://github.com/rdfjs/N3.js/issues/324
-  // @ts-expect-error
-  // eslint-disable-next-line no-underscore-dangle
-  parser._supportsRDFStar = true;
   try {
-    return parser.parse(res);
+    return new Parser({ format: 'text/n3' }).parse(res);
   } catch (e) {
-    throw new Error(`Error while parsing query result: [${e}]. Query result: [${res}]`);
+    // The reasoner emits N-Quads style statements when the input contains quads
+    // (see https://github.com/eyereasoner/eye-js/issues/1642), and the N3.js parser
+    // rejects the 4th (graph) term in text/n3 mode; retry in the permissive default
+    // mode, which accepts quads, before giving up.
+    try {
+      return new Parser().parse(res);
+    } catch {
+      throw new Error(`Error while parsing query result: [${e}]. Query result: [${res}]`);
+    }
   }
 }
 


### PR DESCRIPTION
🚧 DRAFT — for @jeswr to review first

> **Note:** This change is agent-generated (Claude Fable 5) from the verified triage of the linked issues.

Closes #1642
Closes #122

## Problem

`n3reasoner(..., { outputType: 'quads' })` throws `Error while parsing query result: [...]` whenever the reasoner output contains a quad (named-graph / 4th term) — reproduced with the exact snippet from #1642. Root cause: `parse()` in `lib/transformers.ts` parses results with `new Parser({ format: 'text/n3' })`, and N3.js rejects the 4th term in `text/n3` mode.

## Fix

- Keep the `text/n3` parser as the primary parse — it is still required for rules/formulae in the output (the permissive default parser rejects `{...} => {...}`).
- On parse failure, retry once with a default-format `new N3.Parser()` (permissive mode), verified to accept the N-Quads-style statements EYE emits for quad input, preserving the graph term.
- If both parsers fail, rethrow with the original (text/n3) error message, so behaviour for genuinely invalid output is unchanged.
- Remove the dead `parser._supportsRDFStar = true` workaround here and in `__test_utils__/util.ts`: N3.js v2 removed that flag (rdfjs/N3.js#324 was closed as obsolete) and this repo is on `n3 ^2.0.1`, so the assignment is a no-op. The existing rdf-star tests exercise this path and still pass.

Note from the triage: forcing `_supportsNamedGraphs = true` on the n3-mode parser instead does **not** work — it breaks `{...} => {...}` parsing. The fallback-parser approach handles both.

## Tests

Added the exact repro from #1642 to `__tests__/node-test.ts`: quad data + `{ ?s ?p ?o ?g } => { ?s ?p ?o ?g }.`, asserting the result quad's graph term is preserved for `outputType: 'quads'`, plus an `outputType: 'string'` case.

## Validation (local, Linux x64, node-only)

- `npx tsc` + the repo eslint script: exit 0 (only pre-existing ignore-pattern warnings)
- `jest __tests__/node-test.ts --coverage=false`: **43 passed, 1 skipped (pre-existing blogic skip), 44 total**, exit 0
- `jest __tests__/cli-test.ts --coverage=false`: **11 passed**, exit 0

Browser/e2e suites are left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)