### PR TITLE
test: Make browser e2e tests deterministic and leak-free

### DIFF
--- a/__tests__/e2e-test.ts
+++ b/__tests__/e2e-test.ts
@@ -3,6 +3,10 @@ import { firefox, chromium, type BrowserType } from 'playwright';
 import { createTestApp } from '../__test_utils__/serve';
 import { data } from '../data/socrates';
 
+// Generous timeout for the reasoner to produce a result on slow CI runners,
+// kept within the overall 120s jest timeout of each test below
+const RESULT_TIMEOUT = 90_000;
+
 describe('Testing browsers', () => {
   let server: Server;
 
@@ -24,28 +28,41 @@ describe('Testing browsers', () => {
     ([browserType, browserName]) => {
       it(`should be able to call the execute function in ${browserName}`, async () => {
         const browser = await browserType.launch();
-        const page = await browser.newPage();
 
-        await page.goto('http://localhost:3001/');
-        await expect(page.textContent('textarea[id=data]').then((r) => r?.trim())).resolves.toEqual(data.trim());
-        await expect(page.textContent('div[id=result]').then((r) => r?.trim())).resolves.toEqual('');
+        // Ensure the browser is always closed, even when an expectation fails;
+        // a leaked browser stops the jest worker from exiting and hangs CI
+        try {
+          const page = await browser.newPage();
 
-        await page.click('button[id=execute]');
-        // Time for new result to be inserted in the DOM
-        await new Promise((res) => { setTimeout(res, 1000); });
+          await page.goto('http://localhost:3001/');
+          await expect(page.textContent('textarea[id=data]').then((r) => r?.trim())).resolves.toEqual(data.trim());
+          await expect(page.textContent('div[id=result]').then((r) => r?.trim())).resolves.toEqual('');
 
-        await expect(page.textContent('textarea[id=data]').then((r) => r?.trim())).resolves.toEqual(data.trim());
-        await expect(page.textContent('div[id=result]').then((r) => r?.trim())).resolves.toEqual('@prefix : .:Socrates a :Mortal.');
+          await page.click('button[id=execute]');
+          // Wait for the reasoner to insert the result into the DOM rather
+          // than sleeping for a fixed amount of time
+          await page.waitForFunction(
+            () => (document.querySelector('div[id=result]')?.textContent ?? '').trim() !== '',
+            undefined,
+            { timeout: RESULT_TIMEOUT },
+          );
 
-        await page.click('button[id=clear]');
-        // Time for new result to be inserted in the DOM
-        await new Promise((res) => { setTimeout(res, 1000); });
+          await expect(page.textContent('textarea[id=data]').then((r) => r?.trim())).resolves.toEqual(data.trim());
+          await expect(page.textContent('div[id=result]').then((r) => r?.trim())).resolves.toEqual('@prefix : .:Socrates a :Mortal.');
 
-        await expect(page.textContent('textarea[id=data]').then((r) => r?.trim())).resolves.toEqual(data.trim());
-        await expect(page.textContent('div[id=result]').then((r) => r?.trim())).resolves.toEqual('');
+          await page.click('button[id=clear]');
+          // Wait for the result to be removed from the DOM
+          await page.waitForFunction(
+            () => (document.querySelector('div[id=result]')?.textContent ?? '').trim() === '',
+            undefined,
+            { timeout: RESULT_TIMEOUT },
+          );
 
-        await page.close();
-        await browser.close();
+          await expect(page.textContent('textarea[id=data]').then((r) => r?.trim())).resolves.toEqual(data.trim());
+          await expect(page.textContent('div[id=result]').then((r) => r?.trim())).resolves.toEqual('');
+        } finally {
+          await browser.close();
+        }
       }, 120_000);
     },
   );


### PR DESCRIPTION
🚧 DRAFT — for @jeswr to review first

> **Note:** This change is agent-generated (Claude Fable 5) from the verified triage of the linked issues.

Closes #704
Closes #385

## The two mechanisms (from the triage)

1. **Flake (#704):** after clicking `execute`, the test slept a fixed `setTimeout(res, 1000)` and then asserted on `div[id=result]`. The page's execute handler fills that div only after `await eyereasoner.n3reasoner(...)` completes, so on a slow runner the assertion races the reasoner and reads an empty div — exactly the `Expected: "@prefix : .:Socrates a :Mortal." / Received: ""` failure in the linked CI run.
2. **Hang (#385):** `page.close()` / `browser.close()` were the last statements of the test body. When any assertion threw, they never ran; the leaked browser kept the jest worker from exiting ("A worker process has failed to exit gracefully..."), which is the mechanism behind the historic 60-minute Windows CI timeouts.

## Change

- Replace both fixed sleeps with `page.waitForFunction()` polling `div[id=result]` textContent: non-empty after `execute` (then assert the exact expected text), empty after `clear`. Each wait has a generous 90s timeout, inside the existing 120s jest timeout, so a genuine failure still terminates promptly instead of hanging.
- Move the browser/page lifecycle into `try`/`finally` so `browser.close()` (which also closes its pages) always runs, pass or fail.

No assertion is weakened — the same exact-text expectations remain.

## Validation

Playwright cannot run on this (production-shared, browserless) box, so **the CI matrix on this PR is the validation** for the behavioural change. Locally validated:

- repo eslint script: exit 0 (only the 3 pre-existing ignore-pattern warnings)
- standalone `tsc --noEmit` type-check of `__tests__/e2e-test.ts` (the repo tsconfig only includes `lib/`): exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)