### PR TITLE
test: Re-enable the blogic reasoning test

### DIFF
--- a/__test_utils__/util.ts
+++ b/__test_utils__/util.ts
@@ -285,7 +285,7 @@ export function universalTests() {
       
       expect(res).rejects.toThrow()
     });
-    it.skip('should execute the n3reasoner using blogic', async () => {
+    it('should execute the n3reasoner using blogic', async () => {
       const resultStr: string = await n3reasoner(blogicData);
       const quads = (new Parser({ format: 'text/n3' })).parse(resultStr);
       expect<Quad[]>(quads).toBeRdfIsomorphic(resultBlogicQuads);

--- a/data/blogic.ts
+++ b/data/blogic.ts
@@ -21,5 +21,10 @@ export const result = `
 @prefix : <urn:example:>.
 @prefix log: <http://www.w3.org/2000/10/swap/log#>.
 
+{
+    _:x a :Person.
+} => {
+    _:x a :Human.
+}.
 <urn:example:Alice> a <urn:example:Human>.
 `;


### PR DESCRIPTION
🚧 DRAFT — for @jeswr to review first

> **Note:** This change is agent-generated (Claude Fable 5) from the verified triage of the linked issue.

Closes #1108

## Background

The blogic test was skipped in #1107 when an EYE update changed the output for the negative-surface example. Running the current bundled EYE (v11.24.4) on `data/blogic.ts` shows it now emits the conditional answer rule alongside the ground answer:

```
@prefix : <urn:example:>.

{
    _:E_5 a :Person.
} => {
    _:E_5 a :Human.
}.
:Alice a :Human.
```

## Change

- Add the conditional answer rule `{ _:x a :Person. } => { _:x a :Human. }.` to the expected `result` in `data/blogic.ts` (keeping the file's existing prefix lines).
- Remove the `.skip` in `__test_utils__/util.ts`.

The assertion uses jest-rdf's `toBeRdfIsomorphic`, so the blank node labelling (`_:x` vs `_:E_5`) is handled by isomorphism.

## Validation (local, Linux x64, node-only)

- `jest __tests__/node-test.ts -t blogic --coverage=false`: **3 passed (incl. the re-enabled test), 39 skipped (non-matching), 42 total**, exit 0
- Full non-browser suite, `jest __tests__/node-test.ts __tests__/cli-test.ts --coverage=false`: **53 passed, 53 total, 0 skipped**, exit 0

The browser (jsdom) suite runs the same `universalTests()` and is left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)