### PR TITLE
🚧 fix: skip Jekyll pages build and prune superseded patch bundles on release

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -138,10 +138,12 @@ jobs:
           path: dist
       - run: mkdir ./bundle
       - name: "Create Bundle"
+        id: bundle
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           version=$(npx semantic-release --dry-run | grep -oP 'The next release version is \K[0-9]+\.[0-9]+\.[0-9]+') || true
+          echo "version=$version" >> "$GITHUB_OUTPUT"
           if [ $version ]
           then
             npm run bundle:webpack -- --name=v$version
@@ -156,3 +158,43 @@ jobs:
           # See: https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: npx semantic-release
+      - name: Prune superseded patch bundles from pages
+        # Keeps per-minor storage on the pages branch bounded: after x.y.z is
+        # published, remove the other per-patch dirs of minor x.y (their
+        # `latest` copies stay). See https://github.com/eyereasoner/eye-js/issues/1845
+        if: steps.bundle.outputs.version != ''
+        env:
+          # Same token as Release: pushes made with github.token do not
+          # trigger the GitHub Pages build, so the pruned tree would never be
+          # deployed.
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          set -euo pipefail
+          version="${{ steps.bundle.outputs.version }}"
+          major="${version%%.*}"
+          rest="${version#*.}"
+          minor="${rest%%.*}"
+          pages="$RUNNER_TEMP/pages-prune"
+          # Blobless + sparse clone: only the released minor's directory is
+          # materialised, so the (large) pages branch never has to fit on the
+          # runner in full. dev/bench and everything else stay untouched.
+          git clone --no-checkout --depth 1 --filter=blob:none --branch pages \
+            "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$pages"
+          git -C "$pages" sparse-checkout set --cone "$major/$minor"
+          git -C "$pages" checkout pages
+          npm run pages:prune -- --name="v$version" --root="$pages"
+          if [ -n "$(git -C "$pages" status --porcelain)" ]
+          then
+            git -C "$pages" config user.name "github-actions[bot]"
+            git -C "$pages" config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git -C "$pages" add -A -- "$major/$minor"
+            git -C "$pages" commit -m "prune patch bundles superseded by v$version"
+            # The benchmark workflow also pushes to this branch (dev/bench);
+            # rebase and retry on a lost race.
+            for attempt in 1 2 3
+            do
+              if git -C "$pages" push origin HEAD:pages; then break; fi
+              git -C "$pages" fetch --depth=50 origin pages
+              git -C "$pages" rebase origin/pages
+            done
+          fi

--- a/README.md
+++ b/README.md
@@ -173,11 +173,11 @@ eyereasoner --nope --quiet ./socrates.n3 --query ./socrates-query.n3
 
 For convenience we provide deploy bundled versions of the eyereasoner on github pages which can be directly used in an HTML document as shown in [this example](https://github.com/eyereasoner/eye-js/tree/main/examples/prebuilt/index.html) which is also [deployed on github pages](https://eyereasoner.github.io/eye-js/example/index.html).
 
-There is a bundled version for each release - which can be found at the url:
+There is a bundled version for the most recent patch release of each minor version - which can be found at the url:
 <p align=center>
 https://eyereasoner.github.io/eye-js/vMajor/vMinor/vPatch/index.js
 
-for instance v2.3.14 has the url https://eyereasoner.github.io/eye-js/2/3/14/index.js. We also have shortcuts for:
+for instance v2.3.14 has the url https://eyereasoner.github.io/eye-js/2/3/14/index.js (superseded patch releases of the same minor version are pruned to keep the deployed site within GitHub Pages size limits - use the [npm package](https://www.npmjs.com/package/eyereasoner) if you need an exact older patch). We also have shortcuts for:
  - the latest version https://eyereasoner.github.io/eye-js/latest/index.js,
  - the latest of each major version https://eyereasoner.github.io/eye-js/vMajor/latest/index.js, and
  - the latest of each minor version https://eyereasoner.github.io/eye-js/vMajor/vMinor/latest/index.js

--- a/__tests__/prune-pages-test.ts
+++ b/__tests__/prune-pages-test.ts
@@ -1,0 +1,110 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { prunePagesTree } from '../scripts/prune-pages';
+
+// Mirrors the layout of the `pages` branch: per-patch bundle dirs, `latest`
+// copies at every level, the deployed example and the benchmark data
+// (dev/bench) written by a separate workflow.
+const fixtureFiles = [
+  '.nojekyll',
+  'latest/index.js',
+  'latest/dynamic-import.js',
+  '4/latest/index.js',
+  '4/10/latest/index.js',
+  '4/10/1/index.js',
+  '4/10/1/dynamic-import.js',
+  '4/10/2/index.js',
+  '4/10/3/index.js',
+  '4/10/3/dynamic-import.js',
+  '4/9/9/index.js',
+  '4/9/latest/index.js',
+  '3/22/0/index.js',
+  '3/22/latest/index.js',
+  '3/latest/index.js',
+  'example/index.html',
+  'dev/bench/data.js',
+  'dev/bench/index.html',
+];
+
+function makeFixture(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'eye-js-pages-'));
+  for (const file of fixtureFiles) {
+    fs.mkdirSync(path.join(root, path.dirname(file)), { recursive: true });
+    fs.writeFileSync(path.join(root, file), `content of ${file}`);
+  }
+  return root;
+}
+
+function listFiles(root: string, prefix = ''): string[] {
+  const files: string[] = [];
+  for (const entry of fs.readdirSync(path.join(root, prefix), { withFileTypes: true })) {
+    const relative = path.join(prefix, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...listFiles(root, relative));
+    } else {
+      files.push(relative);
+    }
+  }
+  return files.sort();
+}
+
+describe('prunePagesTree', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = makeFixture();
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('removes only the superseded patch dirs of the released minor', () => {
+    const { removed, kept } = prunePagesTree(root, '4.10.3');
+
+    expect(removed).toEqual([path.join('4', '10', '1'), path.join('4', '10', '2')]);
+    expect(kept).toEqual([path.join('4', '10', '3'), path.join('4', '10', 'latest')]);
+    expect(listFiles(root)).toEqual(fixtureFiles
+      .filter((file) => !file.startsWith('4/10/1/') && !file.startsWith('4/10/2/'))
+      .map((file) => path.join(...file.split('/')))
+      .sort());
+  });
+
+  it('does not delete anything on a dry run but still reports the plan', () => {
+    const before = listFiles(root);
+    const { removed } = prunePagesTree(root, '4.10.3', true);
+
+    expect(removed).toEqual([path.join('4', '10', '1'), path.join('4', '10', '2')]);
+    expect(listFiles(root)).toEqual(before);
+  });
+
+  it('is a no-op for a minor version with no directory yet', () => {
+    const before = listFiles(root);
+    const { removed, kept } = prunePagesTree(root, '5.0.0');
+
+    expect(removed).toEqual([]);
+    expect(kept).toEqual([]);
+    expect(listFiles(root)).toEqual(before);
+  });
+
+  it('is a no-op when the released patch is the only one', () => {
+    const before = listFiles(root);
+    const { removed, kept } = prunePagesTree(root, '3.22.0');
+
+    expect(removed).toEqual([]);
+    expect(kept).toEqual([path.join('3', '22', '0'), path.join('3', '22', 'latest')]);
+    expect(listFiles(root)).toEqual(before);
+  });
+
+  it('rejects malformed versions', () => {
+    expect(() => prunePagesTree(root, '4.10')).toThrow(/major\.minor\.patch/);
+    expect(() => prunePagesTree(root, 'v4.10.3')).toThrow(/major\.minor\.patch/);
+    expect(() => prunePagesTree(root, '4.10.x')).toThrow(/major\.minor\.patch/);
+    expect(() => prunePagesTree(root, '../dev.0.0')).toThrow(/major\.minor\.patch/);
+  });
+
+  it('rejects a missing pages root', () => {
+    expect(() => prunePagesTree(path.join(root, 'nope'), '4.10.3')).toThrow(/does not exist/);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "build:tsc": "tsc",
     "bundle:webpack": "webpack --config webpack.config.js",
     "bundle:latest": "ts-node scripts/post-webpack",
+    "pages:prune": "ts-node scripts/prune-pages",
     "semantic-release": "semantic-release",
     "eye:pvm": "ts-node scripts/generate-pvm",
     "eye:pvm:test": "ts-node scripts/run-pvm",
@@ -132,6 +133,7 @@
           "msg": "add version <%= nextRelease.gitTag %>",
           "branch": "pages",
           "add": true,
+          "dotfiles": true,
           "src": "bundle"
         }
       ]

--- a/scripts/post-webpack.ts
+++ b/scripts/post-webpack.ts
@@ -22,4 +22,10 @@ if (version) {
     }
     fs.copySync(path.join(__dirname, '..', ...version), destDir);
   }
+
+  // Publish a .nojekyll marker at the root of the pages site so GitHub skips
+  // the Jekyll build (which copies the whole multi-GB site on the runner and
+  // has been failing with "No space left on device").
+  // See https://github.com/eyereasoner/eye-js/issues/1845
+  fs.writeFileSync(path.join(__dirname, '..', version[0], '.nojekyll'), '');
 }

--- a/scripts/prune-pages.ts
+++ b/scripts/prune-pages.ts
@@ -1,0 +1,70 @@
+/* eslint-disable no-console */
+// Prunes superseded per-patch bundle directories from a checkout of the
+// `pages` branch. When version x.y.z is published, every other numeric patch
+// directory of the same minor version (x/y/<patch>) is removed, so per-minor
+// storage stays bounded at one patch directory plus the `latest` copies.
+//
+// Only entries directly under <root>/<major>/<minor>/ whose names are plain
+// numbers are ever touched; `latest` copies (latest/, <major>/latest/,
+// <major>/<minor>/latest/), other minors/majors, `example/` and `dev/bench`
+// (written by the benchmark workflow) are never modified.
+// See https://github.com/eyereasoner/eye-js/issues/1845
+import fs from 'fs';
+import path from 'path';
+
+export interface PruneResult {
+  /** Paths (relative to root) that were removed (or would be, on a dry run) */
+  removed: string[];
+  /** Paths (relative to root) within the minor dir that were kept */
+  kept: string[];
+}
+
+export function prunePagesTree(root: string, version: string, dryRun = false): PruneResult {
+  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(version);
+  if (!match) {
+    throw new Error(`Expected a numeric version of the form major.minor.patch, got "${version}"`);
+  }
+  const [, major, minor, patch] = match;
+
+  if (!fs.existsSync(root)) {
+    throw new Error(`Pages root "${root}" does not exist`);
+  }
+
+  const removed: string[] = [];
+  const kept: string[] = [];
+  const minorDir = path.join(root, major, minor);
+
+  if (fs.existsSync(minorDir)) {
+    for (const entry of fs.readdirSync(minorDir, { withFileTypes: true })) {
+      const relative = path.join(major, minor, entry.name);
+      if (entry.isDirectory() && /^\d+$/.test(entry.name) && entry.name !== patch) {
+        removed.push(relative);
+        if (!dryRun) {
+          fs.rmSync(path.join(minorDir, entry.name), { recursive: true, force: true });
+        }
+      } else {
+        kept.push(relative);
+      }
+    }
+  }
+
+  return { removed: removed.sort(), kept: kept.sort() };
+}
+
+if (require.main === module) {
+  const version = process.argv.find((arg) => arg.startsWith('--name='))?.slice(8);
+  const root = process.argv.find((arg) => arg.startsWith('--root='))?.slice(7);
+  const dryRun = process.argv.includes('--dry-run');
+
+  if (!version || !root) {
+    console.error('Usage: ts-node scripts/prune-pages --name=vX.Y.Z --root=<pages checkout> [--dry-run]');
+    process.exit(1);
+  }
+
+  const { removed, kept } = prunePagesTree(root, version, dryRun);
+  console.log(`${dryRun ? 'Would remove' : 'Removed'} ${removed.length} superseded patch dir(s) for v${version}:`);
+  for (const dir of removed) {
+    console.log(`  - ${dir}`);
+  }
+  console.log(`Kept within this minor: ${kept.join(', ') || '(none)'}`);
+}


### PR DESCRIPTION
# 🚧 Release-flow fix for the failing pages deployment

> **Note**: This PR was generated by an agent on @jeswr's behalf, following up on the triage in #1845. Please review accordingly.

References #1845 (intentionally not "Closes" — the pages branch is still ~7.4GB until the separate one-off prune below is approved and executed, so the deployment failure can recur in the meantime).

**This PR performs no pages-branch surgery.** It only changes the release flow going forward.

## What this changes

### 1. Skip the Jekyll build (`.nojekyll`) — immediate mitigation
The failing step is GitHub's implicit `pages-build-deployment` Jekyll build, which copies the whole ~7.4GB site on the runner and dies with `No space left on device`. `scripts/post-webpack.ts` now writes an empty `.nojekyll` marker at the bundle root, and the `@qiwi/semantic-release-gh-pages-plugin` config gains `"dotfiles": true` — without it the plugin's `gh-pages` globbing (`**/*` with `dot: false` by default) silently drops the file. Once the next release publishes it, Jekyll is skipped entirely. (The 1GB GitHub Pages site limit still applies, hence 2. and the one-off prune.)

### 2. Stop the regrowth — bound per-minor storage
Each release adds ~32MB (patch dir + `latest` + `vMajor/latest` + `vMajor/vMinor/latest`, each holding `index.js` + `dynamic-import.js` at ~4MB) and `"add": true` means nothing is ever removed. Now, after `semantic-release` publishes `x.y.z`, a new workflow step prunes the superseded patch dirs of minor `x.y` from the pages branch:

- **Never touched**: `latest/`, `vMajor/latest`, `vMajor/vMinor/latest` (all documented URL shapes in the README keep working), `example/`, other minors/majors, and `dev/bench` (written by the benchmark workflow — the prune only ever deletes numeric dirs directly under `<major>/<minor>/`, so it cannot reach it by construction).
- **Removed**: numeric patch dirs of the released minor other than the one just published — e.g. publishing 4.10.3 removes `4/10/1` and `4/10/2`. Per-minor storage is thus bounded at one patch dir + the latest copies. (Pinning an exact older patch remains possible via the npm package; README updated to say so.)
- **Mechanics**: blobless sparse clone (`--filter=blob:none` + cone sparse-checkout of `<major>/<minor>` only), so the runner never materialises the large branch; `ts-node scripts/prune-pages` decides what to delete; push uses the same `GH_TOKEN` as the release (a `github.token` push would not trigger the Pages deployment) with a fetch+rebase retry loop in case the benchmark writer races.

The prune logic lives in `scripts/prune-pages.ts` (exported + CLI with `--dry-run`) and is covered by a new jest suite.

## Dry-run evidence (local, no publish, no pages push)

Fixture tree mirroring the pages branch (`latest/`, `4/latest`, `4/10/{1,2,3,latest}`, `4/9/{9,latest}`, `3/22/{0,latest}`, `3/latest`, `example/`, `dev/bench/`, `.nojekyll`):

```
$ npm run pages:prune -- --name=v4.10.3 --root=<fixture> --dry-run
Would remove 2 superseded patch dir(s) for v4.10.3:
  - 4/10/1
  - 4/10/2
Kept within this minor: 4/10/3, 4/10/latest
# tree verified byte-identical after dry run
```

Real run against the fixture removes exactly `4/10/1` and `4/10/2`; everything else (including `dev/bench` and all `latest` shapes) verified untouched.

End-to-end rehearsal of the exact workflow step against a local bare repo standing in for `origin` (blobless sparse clone → prune → commit → push): resulting `pages` tree keeps `.nojekyll`, `3/22/{0,latest}`, `4/9/{9,latest}`, `4/10/{3,latest}`, all `latest` shapes, `example/`, `dev/bench` — only `4/10/1` and `4/10/2` dropped. A second rehearsal with a competing `dev/bench` commit pushed mid-flight confirmed the retry loop recovers (rejected push → fetch+rebase → push OK on attempt 2) with **both** the bench update and the prune preserved.

`.nojekyll` path: `post-webpack.ts` smoke-tested in an isolated fake repo — `bundle/.nojekyll` (0 bytes) created alongside the usual `dynamic-import.js` and the three `latest` copies.

Validation: `eslint` on touched files exit 0; `tsc --noEmit` on the new/changed scripts + test exit 0; new jest suite 6/6 passing; workflow YAML parses.

## One-off prune (separate sign-off)

**Not part of this PR — awaiting explicit approval from @jeswr before anything is done to the pages branch.** This PR only bounds future growth; the branch is already ~7.4GB (2,974 files, 188 minor dirs), ~7x the 1GB Pages limit. The proposed one-off action is:

- Rewrite the `pages` branch as a **single orphan commit** (shrinking clone/checkout size, not just the deployed tree) containing only: `dev/bench` (benchmark history), `example/`, `latest/`, every `vMajor/latest`, every `vMajor/vMinor/latest`, and the current patch dir of the newest minor, plus `.nojekyll`.
- **Consequences**: historical per-patch URLs (`/x/y/z/index.js` for superseded patches) stop resolving — anyone pinning them should move to `vMajor/vMinor/latest` or the npm package, where every published bundle remains available forever (`dist/` ships in the `eyereasoner` package). All documented URL shapes in the README keep working.
- Force-push of the rewritten branch is the only step that needs the sign-off; it is independent of (but complementary to) this PR and can happen before or after merge.

Happy to adjust retention (e.g. keep the last N patch dirs per minor instead of one) if preferred — the prune script takes the decision in one place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
