### PR TITLE
ci: mark major dependabot bumps as breaking and run CI on merge groups

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -13,54 +13,53 @@ jobs:
       repository-projects: write
     if: github.actor == 'dependabot[bot]'
     steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
-      
-      - name: Handle swipl-wasm updates with semantic commits
-        if: contains(github.head_ref, 'dependabot/npm_and_yarn/swipl-wasm-')
+      - name: Fetch dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+
+      # Squash merges take their commit message from the PR title and body
+      # (squash_merge_commit_title=PR_TITLE, squash_merge_commit_message=PR_BODY),
+      # which semantic-release then analyses on main to pick the release type.
+      # The angular preset does NOT understand the "type!:" shorthand, so a major
+      # release has to be signalled with a "BREAKING CHANGE:" footer in the body.
+
+      - name: Retitle minor swipl-wasm updates as features
+        if: |
+          contains(steps.metadata.outputs.dependency-names, 'swipl-wasm') &&
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
         run: |
-          # Get the old version from the base branch
-          git checkout ${{ github.event.pull_request.base.sha }}
-          OLD_VERSION=$(node -pe "JSON.parse(require('fs').readFileSync('package.json', 'utf8')).dependencies['swipl-wasm']")
-          
-          # Get the new version from the PR branch
-          git checkout ${{ github.event.pull_request.head.sha }}
-          NEW_VERSION=$(node -pe "JSON.parse(require('fs').readFileSync('package.json', 'utf8')).dependencies['swipl-wasm']")
-          
-          # Parse version numbers (remove any ^ or ~ prefixes)
-          OLD_CLEAN=$(echo $OLD_VERSION | sed 's/[^0-9.]//g')
-          NEW_CLEAN=$(echo $NEW_VERSION | sed 's/[^0-9.]//g')
-          
-          OLD_MAJOR=$(echo $OLD_CLEAN | cut -d. -f1)
-          OLD_MINOR=$(echo $OLD_CLEAN | cut -d. -f2)
-          OLD_PATCH=$(echo $OLD_CLEAN | cut -d. -f3)
-          
-          NEW_MAJOR=$(echo $NEW_CLEAN | cut -d. -f1)
-          NEW_MINOR=$(echo $NEW_CLEAN | cut -d. -f2)
-          NEW_PATCH=$(echo $NEW_CLEAN | cut -d. -f3)
-          
-          # Determine semantic commit type
-          if [ "$NEW_MAJOR" -gt "$OLD_MAJOR" ]; then
-            COMMIT_MESSAGE="BREAKING CHANGE: update swipl-wasm to $NEW_VERSION"
-            COMMIT_BODY="BREAKING CHANGE: Updated swipl-wasm from $OLD_VERSION to $NEW_VERSION. This major version update may contain breaking changes."
-          elif [ "$NEW_MINOR" -gt "$OLD_MINOR" ]; then
-            COMMIT_MESSAGE="feat: update swipl-wasm to $NEW_VERSION"
-            COMMIT_BODY="Updated swipl-wasm from $OLD_VERSION to $NEW_VERSION with new features."
-          else
-            COMMIT_MESSAGE="fix: update swipl-wasm to $NEW_VERSION"
-            COMMIT_BODY="Updated swipl-wasm from $OLD_VERSION to $NEW_VERSION with bug fixes."
+          gh pr edit "$PR_URL" --title "feat: update swipl-wasm to $NEW_VERSION"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          NEW_VERSION: ${{ steps.metadata.outputs.new-version }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+
+      - name: Mark major production dependency updates as breaking
+        if: |
+          contains(github.head_ref, 'dependabot/npm_and_yarn/') &&
+          steps.metadata.outputs.dependency-type == 'direct:production' &&
+          steps.metadata.outputs.update-type == 'version-update:semver-major'
+        run: |
+          gh pr view "$PR_URL" --json body --jq .body > body.md
+          # Guard so re-runs (e.g. on synchronize) do not append the footer twice
+          if ! grep -q '^BREAKING CHANGE:' body.md; then
+            printf '\n\nBREAKING CHANGE: %s updated from %s to %s (new major version). This update may contain breaking changes.\n' \
+              "$DEPENDENCY_NAMES" "$PREVIOUS_VERSION" "$NEW_VERSION" >> body.md
+            gh pr edit "$PR_URL" --body-file body.md
           fi
-          
-          gh pr merge ${{ github.event.pull_request.html_url }} --auto --squash --subject "$COMMIT_MESSAGE" --body "$COMMIT_BODY"
-          
-      - name: Auto-merge regular dependabot PRs
-        if: "!contains(github.head_ref, 'dependabot/npm_and_yarn/swipl-wasm-')"
-        run: gh pr merge ${{ github.event.pull_request.html_url }} --auto --squash
-    env:
-      # You may be tempted to make this github.token, this won't work
-      # because GH Actions does not trigger workflows on github.token
-      # in order to avoid recursive workflows.
-      # See: https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
-      GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          DEPENDENCY_NAMES: ${{ steps.metadata.outputs.dependency-names }}
+          PREVIOUS_VERSION: ${{ steps.metadata.outputs.previous-version }}
+          NEW_VERSION: ${{ steps.metadata.outputs.new-version }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+
+      - name: Enable automerge
+        run: gh pr merge "$PR_URL" --auto --squash
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          # You may be tempted to make this github.token, this won't work
+          # because GH Actions does not trigger workflows on github.token
+          # in order to avoid recursive workflows.
+          # See: https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,6 +13,7 @@ name: "CodeQL"
 
 on:
   pull_request:
+  merge_group:
   schedule:
     - cron: '35 10 * * 2'
 

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -8,6 +8,7 @@ on:
     branches:
     - main
   pull_request:
+  merge_group:
 
 jobs:
   build:


### PR DESCRIPTION
### What

- **`automerge.yml`**: use `dependabot/fetch-metadata` to inspect the semver level of each dependabot update instead of hand-parsing swipl-wasm versions out of `package.json`.
  - Major bumps of production npm dependencies now append a `BREAKING CHANGE:` footer to the PR body, so the squash commit triggers a semantic-release **major**. Previously a major bump such as swipl-wasm 7 -> 8 (#1945) kept its `fix:` title and would ship as a patch; the old `gh pr merge --subject "BREAKING CHANGE: ..."` approach also put the note in the squash *subject*, which the angular commit parser cannot read (verified: it yields **no** release), and `--subject`/`--body` flags are ignored by merge queues anyway.
  - Minor swipl-wasm updates keep their `feat:` mapping (now via a PR retitle); patch bumps, dev-dependency bumps and github-actions bumps keep their current `fix:`/`chore:` behaviour.
  - The old flow checked out the PR head under `pull_request_target`; the new flow does not check out any code.
- **`nodejs.yml`**, **`codeql-analysis.yml`**: add `merge_group:` triggers so all required checks also run for merge-queue entries.

### Why

semantic-release's default (angular) commit-analyzer treats a commit as a major only when a line of the commit *body* starts with `BREAKING CHANGE:`. It does not understand the `type!:` shorthand — verified against `@semantic-release/commit-analyzer@13.0.1` as pinned in the lockfile, where `fix!: ...` produces *no* release at all.

Repository squash settings were switched to `squash_merge_commit_title=PR_TITLE` / `squash_merge_commit_message=PR_BODY`, so the PR title and body deterministically become the squash commit message (previously a single-commit PR used the commit's own message, ignoring PR title edits). This is what both the reworked automerge flow and the merge queue rely on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
