### PR TITLE
docs: add sparq development notice to the top of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
 # EYE JS
+
+> [!NOTE]
+> **[@jeswr](https://github.com/jeswr) is now actively developing [sparq](https://github.com/sparq-org/sparq) — a Rust-native RDF triplestore and SPARQL 1.1/1.2 engine with N3 reasoning support** (RDFS / OWL 2 RL / Notation3 forward rules, available natively and as a WebAssembly bundle), plus SHACL validation and more.
+> sparq's browser reasoning bundle is smaller than eye-js's (≈2.6 MB wasm, ≈0.9 MB gzipped, vs eye-js's ≈3.8 MB wasm + data image / ≈4.1 MB browser bundle), and in [sparq's same-machine benchmarks](https://github.com/sparq-org/sparq/blob/main/bench/inference/eye-comparison.md) its N3 forward-closure materialisation runs orders of magnitude faster than the native EYE reasoner (the engine eye-js distributes) on rule-heavy workloads — ≈62× on DeepTaxonomy-1k, widening with depth — while computing identical closures.
+> sparq is pre-1.0 and evolving quickly; an eye-js-compatible npm package to ease migration is tracked in [sparq-org/sparq#1499](https://github.com/sparq-org/sparq/issues/1499).
+
 Distributing the [EYE](https://github.com/eyereasoner/eye) reasoner for browser and node using WebAssembly.
 
 [![GitHub license](https://img.shields.io/github/license/eyereasoner/eye-js.svg)](https://github.com/eyereasoner/eye-js/blob/master/LICENSE)

--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 > [!NOTE]
 > **[@jeswr](https://github.com/jeswr) is now actively developing [sparq](https://github.com/sparq-org/sparq) — a Rust-native RDF triplestore and SPARQL 1.1/1.2 engine with N3 reasoning support** (RDFS / OWL 2 RL / Notation3 forward rules, available natively and as a WebAssembly bundle), plus SHACL validation and more.
-> sparq's browser reasoning bundle is smaller than eye-js's (≈2.6 MB wasm, ≈0.9 MB gzipped, vs eye-js's ≈3.8 MB wasm + data image / ≈4.1 MB browser bundle), and in [sparq's same-machine benchmarks](https://github.com/sparq-org/sparq/blob/main/bench/inference/eye-comparison.md) its N3 forward-closure materialisation runs orders of magnitude faster than the native EYE reasoner (the engine eye-js distributes) on rule-heavy workloads — ≈62× on DeepTaxonomy-1k, widening with depth — while computing identical closures.
-> sparq is pre-1.0 and evolving quickly; an eye-js-compatible npm package to ease migration is tracked in [sparq-org/sparq#1499](https://github.com/sparq-org/sparq/issues/1499).
+> sparq's browser reasoning bundle is smaller than eye-js's (≈2.6 MB wasm, ≈0.9 MB gzipped, vs eye-js's ≈3.8 MB wasm + data image / ≈4.1 MB browser bundle).
+> On the DeepTaxonomy-1k reasoning benchmark, sparq (native Rust) materialises the depth-1000 closure in ≈7 ms of engine time — ≈70 ms end-to-end including process startup, per [sparq's published benchmarks](https://github.com/sparq-org/sparq/blob/main/bench/inference/eye-comparison.md) — while eye-js, the WebAssembly build of the EYE reasoner, completes the same benchmark in ≈390 ms end-to-end (measured on a 2-core CI box; of that, ≈270 ms is one-time WASM module instantiation and ≈120 ms is reasoning). Note this is a **native-vs-WASM** comparison — sparq does not yet publish a WASM DeepTaxonomy timing — so it reflects both the engine and the native-vs-WASM runtime gap: the difference is roughly an order of magnitude on reasoning time and several-fold end-to-end.
+> sparq is an experimental, pre-1.0 research engine evolving quickly; an eye-js-compatible npm package to ease migration is tracked in [sparq-org/sparq#1499](https://github.com/sparq-org/sparq/issues/1499).
 
 Distributing the [EYE](https://github.com/eyereasoner/eye) reasoner for browser and node using WebAssembly.
 


### PR DESCRIPTION
## 🚧 Draft — agent-generated, for @jeswr's wording/figures review before landing

Adds a `> [!NOTE]` banner at the very top of the README (directly under the H1) announcing that @jeswr is now actively developing [sparq](https://github.com/sparq-org/sparq), for eye-js users to find the successor project. Nothing else in the README is touched.

### Direct eye-js-vs-sparq DeepTaxonomy comparison (+ the caveat)

The speed line no longer reuses sparq's **sparq-vs-native-EYE** figure ("orders of magnitude faster than the native EYE reasoner… ≈62×"). That 62× compared sparq against the standalone native EYE binary running a *full forward `--pass` closure* — a different task from what eye-js's own bench actually runs, so quoting it against eye-js would have been misleading.

Instead the notice now states a **direct eye-js-vs-sparq** DeepTaxonomy-1k comparison with measured numbers:

- **sparq (native Rust):** ≈7 ms engine time / ≈70 ms end-to-end incl. process startup, from [sparq's published benchmarks](https://github.com/sparq-org/sparq/blob/main/bench/inference/eye-comparison.md) (idle-machine wall-clock dt1k 0.068 s; engine-internal min-of-5 ≈0.005–0.007 s).
- **eye-js (WASM build of EYE):** ≈390 ms end-to-end, measured on-box (eyereasoner v21.1.10, node 22, 2-core CI box, gated) on the canonical linear DeepTaxonomy-1k shape from `perf/bench.ts` — of which ≈270 ms is one-time WASM module instantiation and ≈120 ms is reasoning.

⚠️ **Caveat, stated explicitly in the notice:** this is a **native-vs-WASM** comparison. sparq publishes **no** WASM DeepTaxonomy timing anywhere, so the honest framing is sparq-native vs eye-js-WASM, and the notice says so — the gap reflects *both* the engine and the native-vs-WASM runtime cost (WASM boot alone is ≈270 ms of eye-js's ≈390 ms). Framed as "roughly an order of magnitude on reasoning time and several-fold end-to-end," not "orders of magnitude." When sparq publishes a WASM DT number this should become a true wasm-vs-wasm line (tracked in #1965).

### Every other figure is verified

| Claim | Source |
|---|---|
| Rust-native RDF triplestore, SPARQL 1.1/1.2 | [sparq README lead](https://github.com/sparq-org/sparq/blob/main/README.md) |
| N3 reasoning (RDFS / OWL 2 RL / Notation3), native + WASM | sparq README features; [`skills/inference/SKILL.md`](https://github.com/sparq-org/sparq/blob/main/skills/inference/SKILL.md); `crates/sparq-reason-wasm`, deployed at `sparq.jeswr.org/wasm/reason/` |
| sparq reasoning bundle ≈2.6 MB wasm / ≈0.9 MB gzip | re-measured from the deployed artifact 2026-07-04: `sparq_reason_wasm_bg.wasm` = 2,572,368 B raw, 909,549 B `gzip -9` |
| eye-js ≈3.8 MB wasm + data / ≈4.1 MB browser bundle | measured from this repo @ `fa76971`: `swipl-web.wasm` 2,190,887 B + `swipl-web.data` 1,642,703 B = 3,833,590 B; webpack `bundle/index.js` 4,051,911 B |
| DeepTaxonomy-1k: sparq ≈7 ms/≈70 ms vs eye-js ≈390 ms | sparq: [`bench/inference/eye-comparison.md`](https://github.com/sparq-org/sparq/blob/main/bench/inference/eye-comparison.md); eye-js: on-box measurement (eyereasoner v21.1.10, canonical `perf/bench.ts` linear DT-1000 shape) |
| experimental / pre-1.0 / evolving quickly | sparq README status banner |
| migration npm package "tracked in sparq-org/sparq#1499" | sparq-org/sparq#1499 — does **not** exist on npm yet, hence *tracked*, not *available* |

Deliberately **not** claimed: any identical-closure guarantee between eye-js and sparq (verified only sparq-vs-native-EYE in the linked file; eye-js's bench uses a goal-directed `--query`, so its derivation may differ), and any published sparq npm package.

### Trackers

- #1965 — broader tracker: keep the notice's **figures** (bundle size, DT timings) and **state** (pre-1.0 → stable, native-vs-WASM framing) current as sparq evolves.
- #1960 — narrow tracker: make the migration pointer concrete (`npm install <name>` + drop-in snippet) once sparq's npm package publishes.

### Adjacency note

⚠️ #1954 (browser dist e2e test + RDF 1.2 support level) also edits README.md. This change is at the very top (under the H1); #1954's edit is in the RDF-1.2 section — different region, so a conflict is unlikely, but rebase after #1954 lands if the merge queue complains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
